### PR TITLE
fix: unescape params

### DIFF
--- a/pkg/request_builder.go
+++ b/pkg/request_builder.go
@@ -122,8 +122,14 @@ func (b *QueryRequestBuilder) ExecuteWithContext(ctx context.Context, r interfac
 	if err != nil {
 		return err
 	}
+	query, err := url.QueryUnescape(b.params.Encode())
 
-	req.URL.RawQuery = b.params.Encode()
+	if err != nil {
+		return err
+	}
+
+	req.URL.RawQuery = query
+
 	req.Header = b.client.Headers()
 
 	// inject/override custom headers


### PR DESCRIPTION
What to fix:
failed to query when target value is url

I got a column whose value is url, for example column name is `url` and the value is `https://www.cnblogs.com/lyzg/p/5125934.html`

When I do the query like this: `client.SupaClient.DB.From(DB_NAME).Select("*").Filter("url", "in", fmt.Sprintf(`("%s")`, url))`
It can't query any record out.

I found it's because `supabase-go` encode the query params before send the request.