### PR TITLE
Update OrderBy function to take params (string, bool) for easier use

### DIFF
--- a/pkg/request_builder.go
+++ b/pkg/request_builder.go
@@ -340,8 +340,12 @@ type SelectRequestBuilder struct {
 }
 
 // OrderBy sets the ordering column and direction for the SELECT request.
-func (b *SelectRequestBuilder) OrderBy(column, direction string) *SelectRequestBuilder {
-	b.params.Set("order", column+"."+direction)
+func (b *SelectRequestBuilder) OrderBy(column string, ascend bool) *SelectRequestBuilder {
+	value := "asc"
+	if !ascend {
+		value = "desc"
+	}
+	b.params.Set("order", column+"."+value)
 	return b
 }
 


### PR DESCRIPTION
Change the OrderBy function parameter to be `string, bool` instead of `string, string`. It's a trivial change but since Order can only either be asc or desc, I think it makes more sense to be a boolean value thing having to specify which. 

And because this isn't in the tag/ released version it won't be a breaking change