### PR TITLE
Remove column name sanitization

### DIFF
--- a/pkg/request_builder.go
+++ b/pkg/request_builder.go
@@ -200,7 +200,7 @@ func (b *FilterRequestBuilder) Filter(column, operator, criteria string) *Filter
 		b.negateNext = false
 		operator = "not." + operator
 	}
-	b.params.Add(SanitizeParam(column), operator+"."+criteria)
+	b.params.Add(column, operator+"."+criteria)
 	return b
 }
 


### PR DESCRIPTION
It seems that since [this ](https://github.com/nedpals/postgrest-go/pull/2) PR, one does not need to sanitize column names: https://github.com/nedpals/supabase-go/issues/28

In the current state, joined filtering does not work for this reason. https://github.com/nedpals/supabase-go/issues/26
By remove the sanitization part it will work again. 